### PR TITLE
Improve documentation and test suite

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Perfect for use with Express Checkout or other API-based solutions
 
 ```html
 <script async src="paypal-button.min.js?merchant=YOUR_MERCHANT_ID"
-    data-button="buynow"
+    data-button="button"
+    data-type="button"
 ></script>
 ```
 
-Any type of button may be used: `buynow`, `cart`, `donate`, or `subscribe`.
-
-
+Any type of button may be used: `button`,`buynow`, `cart`, `donate`, or `subscribe`.
 
 ## PayPal Payments Standard Buttons
 
@@ -31,7 +30,7 @@ Buy Now buttons are for single item purchases.
 ```html
 <script async src="paypal-button.min.js?merchant=YOUR_MERCHANT_ID"
     data-button="buynow"
-    data-type="form"
+    data-type="buynow"
     data-name="My product"
     data-amount="1.00"
 ></script>
@@ -46,7 +45,7 @@ Add To Cart buttons let users add multiple items to their PayPal cart.
 ```html
 <script async src="paypal-button.min.js?merchant=YOUR_MERCHANT_ID"
     data-button="cart"
-    data-type="form"
+    data-type="cart"
     data-name="Product in your cart"
     data-amount="1.00"
 ></script>
@@ -70,7 +69,7 @@ Donation buttons let you accept donations from your users.
 ```html
 <script async src="paypal-button.min.js?merchant=YOUR_MERCHANT_ID"
     data-button="donate"
-    data-type="form"
+    data-type="donate"
     data-name="My donation"
     data-amount="1.00"
 ></script>
@@ -82,13 +81,17 @@ Subscribe buttons let you set up payment subscriptions.
 ```html
 <script async src="paypal-button.min.js?merchant=YOUR_MERCHANT_ID"
     data-button="subscribe"
-    data-type="form"
+    data-type="subscribe"
     data-name="My product"
     data-amount="1.00"
     data-recurrence="1"
     data-period="M"
 ></script>
 ```
+The `data-recurrence` attribute specifies how many 'units' the subscription lasts for, while `data-period` sets the units `M is Month, D is Days etc`.  See [Recurring Payment Buttons](https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/Appx_websitestandard_htmlvariables/#id08A6HI00JQU) for more information.
+
+If you need payments to recur, add `data-src="1"`
+
 
 ## PayPal Payments Standard Features
 
@@ -107,8 +110,9 @@ All of PayPal's [HTML button variables](https://developer.paypal.com/webapps/dev
 * `data-locale` The desired locale of the PayPal site.
 * `data-callback` The IPN notify URL to be called on completion of the transaction.
 * `data-host` The PayPal host to checkout in, e.g. `www.sandbox.paypal.com` (defaults to 'www.paypal.com').
-* `data-type` The type of button to render. `button` for a plain button (default), `form` to create a button with a PayPal Payments Standard HTML form, or `qr` to create a PayPal Payments Standard compatible QR code.
-
+* `data-type` The type of button to render. `button` for a plain button (default), other options include `subscribe`, `donate`, `form`, `cart` and `qr`
+* `data-no_shipping` Whether the item requires an address `0` - prompt, but don't require `1` do not prompt `2` prompt and require
+* `data-custom` Pass through variable for your own tracking purposes, up to 256 characters
 
 ### Editable inputs
 Creating editable inputs is easy. Just add `-editable` to the name of your variable, e.g. `data-quantity-editable`, and an input field will magically appear for your users.

--- a/test/functional/index.html
+++ b/test/functional/index.html
@@ -143,7 +143,7 @@
 		<h2>Cart (Small)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="cart"
-			data-type="form"
+			data-type="cart"
 			data-name="Add to cart!"
 			data-amount="1.00"
 			data-size="small"
@@ -154,7 +154,7 @@
 		<h2>Cart (Medium)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="cart"
-			data-type="form"
+			data-type="cart"
 			data-name="Add to cart!"
 			data-amount="1.00"
 			data-size="medium"
@@ -165,7 +165,7 @@
 		<h2>Cart (Large)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="cart"
-			data-type="form"
+			data-type="cart"
 			data-name="Add to cart!"
 			data-amount="1.00"
 			data-size="large"
@@ -176,7 +176,7 @@
 		<h2>Donate (Small)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="donate"
-			data-type="form"
+			data-type="donate"
 			data-name="Donate!"
 			data-amount="1.00"
 			data-size="small"
@@ -187,7 +187,7 @@
 		<h2>Donate (Medium)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="donate"
-			data-type="form"
+			data-type="donate"
 			data-name="Donate!"
 			data-amount="1.00"
 			data-size="medium"
@@ -198,7 +198,7 @@
 		<h2>Donate (Large)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="donate"
-			data-type="form"
+			data-type="donate"
 			data-name="Donate!"
 			data-amount="1.00"
 			data-size="large"
@@ -209,7 +209,7 @@
 		<h2>Subscribe (Small)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="subscribe"
-			data-type="form"
+			data-type="subscribe"
 			data-name="Subscribe!"
 			data-size="small"
 			data-amount="1.00"
@@ -222,7 +222,7 @@
 		<h2>Subscribe (Medium)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="subscribe"
-			data-type="form"
+			data-type="subscribe"
 			data-name="Subscribe!"
 			data-size="medium"
 			data-amount="1.00"
@@ -235,7 +235,7 @@
 		<h2>Subscribe (Large)</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="subscribe"
-			data-type="form"
+			data-type="subscribe"
 			data-name="Subscribe!"
 			data-size="large"
 			data-amount="1.00"
@@ -244,7 +244,22 @@
 		></script>
 	</div>
 
-	<div id="button-id">
+    <div id="subscribe-recur">
+        <h2>Subscribe (Recurring)</h2>
+        <script src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
+            data-button="subscribe"
+            data-type="subscribe"
+            data-size="small"
+            data-name="Subscribe - 6 Months"
+            data-amount="100"
+            data-recurrence="6"
+            data-period="M"
+            data-src="1"
+            >
+        </script>
+    </div>
+
+	<div id="button-hosted">
 		<h2>Hosted button</h2>
 		<script async src="../../dist/button.js?merchant=6XF3MPZBZV6HU"
 			data-button="buynow"

--- a/test/functional/spec/test.js
+++ b/test/functional/spec/test.js
@@ -64,7 +64,7 @@ describe('Test page button counter', function () {
 	});
 
 	it('Should have two subscribe buttons', function () {
-		buttons.subscribe.should.equal(3);
+		buttons.subscribe.should.equal(4);
 	});
 });
 
@@ -203,7 +203,7 @@ describe('Styled buttons', function () {
 	});
 
 	it('Should have primary buttons', function () {
-		primary.length.should.equal(20);
+		primary.length.should.equal(21);
 	});
 
 	it('Should have secondary buttons', function () {
@@ -234,4 +234,50 @@ describe('Options buttons', function () {
 		selects[1].options[0].value.should.equal('Tiny');
 	});
 
+});
+
+describe('Subscription buttons', function () {
+    it('Can have a recurrence field', function () {
+        var recurrent = document.getElementById('subscribe-recur').querySelector('[name="src"]');
+        recurrent.value.should.equal('1');
+    });
+
+    it('Should set command to _xclick-subscriptions', function () {
+        var cmd = document.getElementById('subscribe-recur').querySelector('[name="cmd"]');
+        cmd.value.should.equal('_xclick-subscriptions');
+    });
+});
+
+describe('Donate button', function () {
+    it('Should set the command to _donations', function () {
+        var cmd = document.getElementById('donate-sm').querySelector('[name="cmd"]');
+        cmd.value.should.equal('_donations');
+    });
+});
+
+describe('Buy now button', function () {
+    it('Should set the command to _xclick', function () {
+        var cmd = document.getElementById('buynow-sm').querySelector('[name="cmd"]');
+        cmd.value.should.equal('_xclick');
+    });
+});
+
+describe('Cart buttons', function () {
+    it('Should set the command to _cart', function () {
+        var cmd = document.getElementById('cart-sm').querySelector('[name="cmd"]');
+        cmd.value.should.equal('_cart');
+    });
+});
+describe('Hosted buttons', function () {
+    it('Should set the command to _s-xclick', function () {
+        var cmd = document.getElementById('button-hosted').querySelector('[name="cmd"]');
+        cmd.value.should.equal('_s-xclick');
+    });
+});
+
+describe('Sandbox environment', function () {
+    it('Should set the url to sandbox environment', function () {
+        var sandbox = document.getElementById('sandbox').getElementsByTagName('form')[0];
+        sandbox.action.should.equal('https://www.sandbox.paypal.com/cgi-bin/webscr');
+    });
 });


### PR DESCRIPTION
Currently the documentation in README is incorrect, meaning that anyone following along may get the wrong button type.

In README `data-type` is shown to always be `form`, but this results in incorrect button rendering.  The test suite does not reflect this either.  Tests have been added which ensure the correct attributes get set on the form, so users are taken to the correct PayPal checkout screen.

Documentation is added for payment recurrence when using a subscription button type.

.editor config also had an error, which has been corrected.